### PR TITLE
Fix GitHub Actions workflow reusability error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_call:
   pull_request:
   push:
     branches:

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule BambooHR.MixProject do
   def project do
     [
       app: :bamboo_hr,
-      version: "0.0.0-dev",
+      version: "0.0.0",
       elixir: "~> 1.17",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
💁 This change fixes the following error when attempting to reuse workflows as part of publishing a Hex package:
```
Invalid workflow file: .github/workflows/publish.yml#L18
error parsing called workflow
".github/workflows/publish.yml"
-> "./.github/workflows/ci.yml" (source branch with sha:64f0ca9293b3b4d7dd3473b92e30685ff2f07159)
: workflow is not reusable as it is missing a `on.workflow_call` trigger
```
([source](https://github.com/sgerrand/ex_bamboo_hr/actions/runs/13032957339))