### PR TITLE
CI: Improve automated release notes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,7 +54,7 @@ jobs:
       run: mix deps.get
 
     - name: Add changelog entry
-      run: echo "${{ inputs.changes }}" > RELEASE.md
+      run: echo -e "${{ inputs.changes }}" > RELEASE.md
 
     - name: Bump version, generate changelog, push to git, publish on hex.pm
       run: mix expublish.${{ inputs.version }} --branch=main --disable-test


### PR DESCRIPTION
💁 Not being able to use non-printing characters in release notes results in an ugly changelog. Carriage returns or line feeds are critical here. These changes enable them to be used as part of the Publish New Version workflow.