### PR TITLE
Configure ExDoc for HexDocs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,36 @@ on:
       - main
 
 jobs:
+  docs:
+    name: Documentation
+    runs-on: ubuntu-latest
+
+    env:
+      MIX_ENV: dev
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Elixir
+      id: setup-beam
+      uses: erlef/setup-beam@v1
+      with:
+        version-file: '.tool-versions'
+        version-type: 'strict'
+    - name: Cache dependencies
+      id: cache-deps
+      uses: actions/cache@v4
+      with:
+        path: |
+          _build
+          deps
+        key: ${{ runner.os }}-${{ env.MIX_ENV }}-${{ steps.setup-beam.outputs.otp-version }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ hashFiles('**/mix.lock') }}
+        restore-keys: ${{ runner.os }}-${{ env.MIX_ENV }}-${{ steps.setup-beam.outputs.otp-version }}-${{ steps.setup-beam.outputs.elixir-version }}-
+    - name: Install and compile dependencies
+      if: steps.cache-deps.outputs.cache-hit != 'true'
+      run: mix do deps.get --only ${{ env.MIX_ENV }}, deps.compile
+    - name: Generate documentation
+      run: mix docs --warnings-as-errors
+
   test:
     name: Tests (Elixir ${{ matrix.elixir }} / OTP ${{ matrix.otp }})
     runs-on: ubuntu-latest

--- a/mix.exs
+++ b/mix.exs
@@ -13,8 +13,12 @@ defmodule BambooHR.MixProject do
       # Hex
       description: "Elixir client for the Bamboo HR API",
       homepage_url: "https://github.com/sgerrand/ex_bamboo_hr",
+      source_url: "https://github.com/sgerrand/ex_bamboo_hr",
       package: package(),
-      source_url: "https://github.com/sgerrand/ex_bamboo_hr"
+
+      # Docs
+      name: "BambooHR",
+      docs: docs()
     ]
   end
 
@@ -35,6 +39,15 @@ defmodule BambooHR.MixProject do
     ]
   end
 
+  defp docs do
+    [
+      main: "readme",
+      source_ref: "v#{@version}",
+      source_url: @source_url,
+      extras: ["README.md", "CHANGELOG.md", "LICENSE"]
+    ]
+  end
+
   defp elixirc_paths(:test), do: ["lib", "test/support"]
   defp elixirc_paths(_), do: ["lib"]
 
@@ -44,6 +57,7 @@ defmodule BambooHR.MixProject do
       licenses: ["MIT"],
       links: %{
         "GitHub" => "https://github.com/sgerrand/ex_bamboo_hr",
+        "Changelog" => "https://hexdocs.pm/bamboo_hr/changelog.html",
         "Sponsor" => "https://github.com/sponsors/sgerrand"
       },
       files: ~w(lib LICENSE mix.exs README.md)

--- a/mix.exs
+++ b/mix.exs
@@ -2,6 +2,7 @@ defmodule BambooHR.MixProject do
   use Mix.Project
 
   @version "0.1.0"
+  @source_url "https://github.com/sgerrand/ex_bamboo_hr"
 
   def project do
     [
@@ -14,8 +15,8 @@ defmodule BambooHR.MixProject do
 
       # Hex
       description: "Elixir client for the Bamboo HR API",
-      homepage_url: "https://github.com/sgerrand/ex_bamboo_hr",
-      source_url: "https://github.com/sgerrand/ex_bamboo_hr",
+      homepage_url: @source_url,
+      source_url: @source_url,
       package: package(),
 
       # Docs
@@ -58,7 +59,7 @@ defmodule BambooHR.MixProject do
       maintainers: ["Sasha Gerrand"],
       licenses: ["MIT"],
       links: %{
-        "GitHub" => "https://github.com/sgerrand/ex_bamboo_hr",
+        "GitHub" => @source_url,
         "Changelog" => "https://hexdocs.pm/bamboo_hr/changelog.html",
         "Sponsor" => "https://github.com/sponsors/sgerrand"
       },

--- a/mix.exs
+++ b/mix.exs
@@ -1,10 +1,12 @@
 defmodule BambooHR.MixProject do
   use Mix.Project
 
+  @version "0.1.0"
+
   def project do
     [
       app: :bamboo_hr,
-      version: "0.1.0",
+      version: @version,
       elixir: "~> 1.17",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
💁 These changes:
- Set the README as the homepage in HexDocs
- Include the license file because it's referenced.
- Include the CHANGELOG
- Add a metadata link to the changelog file in HexDocs

I've also added another job to the existing CI workflow to validate that the package documentation will be generated without errors or warnings.