### PR TITLE
CI: There can be only one

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,15 @@ on:
       - main
 
 jobs:
+  required:
+    name: Required
+    needs: [docs, test]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Status of workflow jobs
+        run: echo 'All jobs in this workflow have successfully run'
+
   docs:
     name: Documentation
     runs-on: ubuntu-latest


### PR DESCRIPTION
![There can be only one job in a workflow](https://github.com/user-attachments/assets/6adc4184-ab31-47a0-b689-f4afedcd0900)

💁 GitHub allows workflow jobs to be configured as required to pass prior to merge. Instead of configuring this individually at the job level, this change uses a different approach by transparently configuring jobs as "needed" within the workflow itself.