### PR TITLE
Update package version, drop patch version

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:bamboo_hr, "~> 0.1.0"}
+    {:bamboo_hr, "~> 0.2"}
   ]
 end
 ```


### PR DESCRIPTION
💁 This change updates the version of the package in the README, in preparation for the next release of this package. Dropping the patch component of the version should reduce the need for regular updates.