### PR TITLE
Configurable client

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,18 @@ The library is organized into several modules, each representing different API r
 First, create a client configuration:
 
 ```elixir
-config = BambooHR.Client.new("your_company", "your_api_key")
+config = BambooHR.Client.new(company_domain: "your_company", api_key: "your_api_key")
+```
+
+You can also specify optional parameters:
+
+```elixir
+config = BambooHR.Client.new(
+  company_domain: "your_company",
+  api_key: "your_api_key",
+  base_url: "https://custom-api.example.com",
+  http_client: YourCustomHTTPClient
+)
 ```
 
 #### Company Information

--- a/lib/bamboo_hr/client.ex
+++ b/lib/bamboo_hr/client.ex
@@ -10,7 +10,7 @@ defmodule BambooHR.Client do
 
   ## Usage
 
-      client = BambooHR.Client.new("your_company", "your_api_key")
+      client = BambooHR.Client.new(company_domain: "your_company", api_key: "your_api_key")
       {:ok, company_info} = BambooHR.Company.get_information(client)
   """
 

--- a/lib/bamboo_hr/company.ex
+++ b/lib/bamboo_hr/company.ex
@@ -12,7 +12,7 @@ defmodule BambooHR.Company do
 
   ## Parameters
 
-    * `client` - Client configuration created with `BambooHR.Client.new/3`
+    * `client` - Client configuration created with `BambooHR.Client.new/1`
 
   ## Examples
 
@@ -35,7 +35,7 @@ defmodule BambooHR.Company do
 
   ## Parameters
 
-    * `client` - Client configuration created with `BambooHR.Client.new/3`
+    * `client` - Client configuration created with `BambooHR.Client.new/1`
 
   ## Examples
 

--- a/lib/bamboo_hr/company.ex
+++ b/lib/bamboo_hr/company.ex
@@ -23,7 +23,7 @@ defmodule BambooHR.Company do
         "city" => "San Francisco"
       }}
   """
-  @spec get_information(Client.config()) :: Client.response()
+  @spec get_information(client :: Client.t()) :: Client.response()
   def get_information(client) do
     Client.get("/company_information", client)
   end
@@ -47,7 +47,7 @@ defmodule BambooHR.Company do
         ]
       }}
   """
-  @spec get_eins(Client.config()) :: Client.response()
+  @spec get_eins(Client.t()) :: Client.response()
   def get_eins(client) do
     Client.get("/company_eins", client)
   end

--- a/lib/bamboo_hr/employee.ex
+++ b/lib/bamboo_hr/employee.ex
@@ -10,7 +10,7 @@ defmodule BambooHR.Employee do
 
   ## Parameters
 
-    * `client` - Client configuration created with `BambooHR.Client.new/3`
+    * `client` - Client configuration created with `BambooHR.Client.new/1`
     * `employee_id` - The ID of the employee to retrieve
     * `fields` - List of field names to retrieve (e.g., ["firstName", "lastName", "jobTitle"])
 
@@ -33,7 +33,7 @@ defmodule BambooHR.Employee do
 
   ## Parameters
 
-    * `client` - Client configuration created with `BambooHR.Client.new/3`
+    * `client` - Client configuration created with `BambooHR.Client.new/1`
     * `employee_data` - Map containing the employee information (firstName and lastName are required)
 
   ## Examples
@@ -52,7 +52,7 @@ defmodule BambooHR.Employee do
 
   ## Parameters
 
-    * `client` - Client configuration created with `BambooHR.Client.new/3`
+    * `client` - Client configuration created with `BambooHR.Client.new/1`
     * `employee_id` - The ID of the employee to update
     * `employee_data` - Map containing the updated employee information
 
@@ -74,7 +74,7 @@ defmodule BambooHR.Employee do
 
   ## Parameters
 
-    * `client` - Client configuration created with `BambooHR.Client.new/3`
+    * `client` - Client configuration created with `BambooHR.Client.new/1`
 
   ## Examples
 

--- a/lib/bamboo_hr/employee.ex
+++ b/lib/bamboo_hr/employee.ex
@@ -23,7 +23,7 @@ defmodule BambooHR.Employee do
         "jobTitle" => "Software Engineer"
       }}
   """
-  @spec get(Client.config(), integer(), list(String.t())) :: Client.response()
+  @spec get(Client.t(), integer(), list(String.t())) :: Client.response()
   def get(client, employee_id, fields) when is_integer(employee_id) do
     Client.get("/employees/#{employee_id}", client, params: [fields: Enum.join(fields, ",")])
   end
@@ -42,7 +42,7 @@ defmodule BambooHR.Employee do
       iex> BambooHR.Employee.add(client, employee_data)
       {:ok, %{"id" => 124}}
   """
-  @spec add(Client.config(), map()) :: Client.response()
+  @spec add(Client.t(), map()) :: Client.response()
   def add(client, employee_data) do
     Client.post("/employees", client, json: employee_data)
   end
@@ -62,7 +62,7 @@ defmodule BambooHR.Employee do
       iex> BambooHR.Employee.update(client, 124, update_data)
       {:ok, %{}}
   """
-  @spec update(Client.config(), integer(), map()) :: Client.response()
+  @spec update(Client.t(), integer(), map()) :: Client.response()
   def update(client, employee_id, employee_data) when is_integer(employee_id) do
     Client.post("/employees/#{employee_id}", client, json: employee_data)
   end
@@ -90,7 +90,7 @@ defmodule BambooHR.Employee do
         ]
       }}
   """
-  @spec get_directory(Client.config()) :: Client.response()
+  @spec get_directory(Client.t()) :: Client.response()
   def get_directory(client) do
     Client.get("/employees/directory", client)
   end

--- a/lib/bamboo_hr/http_client.ex
+++ b/lib/bamboo_hr/http_client.ex
@@ -1,0 +1,29 @@
+defmodule BambooHR.HTTPClient do
+  @moduledoc """
+  Behaviour for HTTP clients.
+  """
+
+  @callback request(keyword()) :: {:ok, map()} | {:error, any()}
+end
+
+defmodule BambooHR.HTTPClient.Req do
+  @moduledoc """
+  HTTP client implementation using `Req`.
+  """
+
+  @behaviour BambooHR.HTTPClient
+
+  @impl true
+  def request(opts) do
+    case Req.request(opts) do
+      {:ok, %{status: status, body: body}} when status in 200..299 ->
+        {:ok, body}
+
+      {:ok, %{status: status, body: body}} ->
+        {:error, %{status: status, body: body}}
+
+      {:error, error} ->
+        {:error, error}
+    end
+  end
+end

--- a/lib/bamboo_hr/time_tracking.ex
+++ b/lib/bamboo_hr/time_tracking.ex
@@ -32,7 +32,7 @@ defmodule BambooHR.TimeTracking do
         ]
       }}
   """
-  @spec get_timesheet_entries(Client.config(), map()) :: Client.response()
+  @spec get_timesheet_entries(Client.t(), map()) :: Client.response()
   def get_timesheet_entries(client, params) do
     Client.get("/time_tracking/timesheet_entries", client, params: params)
   end
@@ -58,7 +58,7 @@ defmodule BambooHR.TimeTracking do
       iex> BambooHR.TimeTracking.store_clock_entries(client, entries)
       {:ok, %{"message" => "Entries stored successfully"}}
   """
-  @spec store_clock_entries(Client.config(), list(map())) :: Client.response()
+  @spec store_clock_entries(Client.t(), list(map())) :: Client.response()
   def store_clock_entries(client, entries) do
     Client.post("/time_tracking/clock_entries/store", client, json: %{items: entries})
   end
@@ -82,7 +82,7 @@ defmodule BambooHR.TimeTracking do
       iex> BambooHR.TimeTracking.clock_in(client, 123, clock_data)
       {:ok, %{"message" => "Successfully clocked in"}}
   """
-  @spec clock_in(Client.config(), integer(), map()) :: Client.response()
+  @spec clock_in(Client.t(), integer(), map()) :: Client.response()
   def clock_in(client, employee_id, clock_data) when is_integer(employee_id) do
     Client.post("/time_tracking/employees/#{employee_id}/clock_in", client, json: clock_data)
   end
@@ -106,7 +106,7 @@ defmodule BambooHR.TimeTracking do
       iex> BambooHR.TimeTracking.clock_out(client, 123, clock_data)
       {:ok, %{"message" => "Successfully clocked out"}}
   """
-  @spec clock_out(Client.config(), integer(), map()) :: Client.response()
+  @spec clock_out(Client.t(), integer(), map()) :: Client.response()
   def clock_out(client, employee_id, clock_data) when is_integer(employee_id) do
     Client.post("/time_tracking/employees/#{employee_id}/clock_out", client, json: clock_data)
   end

--- a/lib/bamboo_hr/time_tracking.ex
+++ b/lib/bamboo_hr/time_tracking.ex
@@ -10,7 +10,7 @@ defmodule BambooHR.TimeTracking do
 
   ## Parameters
 
-    * `client` - Client configuration created with `BambooHR.Client.new/3`
+    * `client` - Client configuration created with `BambooHR.Client.new/1`
     * `params` - Map containing query parameters (start, end dates, and optional employee IDs)
 
   ## Examples
@@ -42,7 +42,7 @@ defmodule BambooHR.TimeTracking do
 
   ## Parameters
 
-    * `client` - Client configuration created with `BambooHR.Client.new/3`
+    * `client` - Client configuration created with `BambooHR.Client.new/1`
     * `entries` - List of clock entry maps containing employee ID, date, start and end times
 
   ## Examples
@@ -68,7 +68,7 @@ defmodule BambooHR.TimeTracking do
 
   ## Parameters
 
-    * `client` - Client configuration created with `BambooHR.Client.new/3`
+    * `client` - Client configuration created with `BambooHR.Client.new/1`
     * `employee_id` - The ID of the employee to clock in
     * `clock_data` - Map containing clock-in details (date, start time, timezone, etc.)
 
@@ -92,7 +92,7 @@ defmodule BambooHR.TimeTracking do
 
   ## Parameters
 
-    * `client` - Client configuration created with `BambooHR.Client.new/3`
+    * `client` - Client configuration created with `BambooHR.Client.new/1`
     * `employee_id` - The ID of the employee to clock out
     * `clock_data` - Map containing clock-out details (date, end time, timezone)
 

--- a/test/bamboo_hr/client_test.exs
+++ b/test/bamboo_hr/client_test.exs
@@ -4,13 +4,16 @@ defmodule BambooHR.ClientTest do
   setup do
     bypass = Bypass.open()
     base_url = "http://localhost:#{bypass.port}/api/gateway.php"
-    config = BambooHR.Client.new("test_company", "test_key", base_url)
+
+    config =
+      BambooHR.Client.new(company_domain: "test_company", api_key: "test_key", base_url: base_url)
+
     {:ok, bypass: bypass, config: config}
   end
 
   describe "new/3" do
     test "creates config with default base URL" do
-      config = BambooHR.Client.new("test_company", "test_key")
+      config = BambooHR.Client.new(company_domain: "test_company", api_key: "test_key")
       assert config.company_domain == "test_company"
       assert config.api_key == "test_key"
       assert config.base_url == "https://api.bamboohr.com/api/gateway.php"
@@ -18,7 +21,14 @@ defmodule BambooHR.ClientTest do
 
     test "creates config with custom base URL" do
       custom_url = "https://custom-bamboohr.example.com"
-      config = BambooHR.Client.new("test_company", "test_key", custom_url)
+
+      config =
+        BambooHR.Client.new(
+          company_domain: "test_company",
+          api_key: "test_key",
+          base_url: custom_url
+        )
+
       assert config.company_domain == "test_company"
       assert config.api_key == "test_key"
       assert config.base_url == custom_url

--- a/test/bamboo_hr/company_test.exs
+++ b/test/bamboo_hr/company_test.exs
@@ -4,7 +4,10 @@ defmodule BambooHR.CompanyTest do
   setup do
     bypass = Bypass.open()
     base_url = "http://localhost:#{bypass.port}/api/gateway.php"
-    config = BambooHR.Client.new("test_company", "test_key", base_url)
+
+    config =
+      BambooHR.Client.new(company_domain: "test_company", api_key: "test_key", base_url: base_url)
+
     [bypass: bypass, config: config]
   end
 

--- a/test/bamboo_hr/employee_test.exs
+++ b/test/bamboo_hr/employee_test.exs
@@ -4,7 +4,10 @@ defmodule BambooHR.EmployeeTest do
   setup do
     bypass = Bypass.open()
     base_url = "http://localhost:#{bypass.port}/api/gateway.php"
-    config = BambooHR.Client.new("test_company", "test_key", base_url)
+
+    config =
+      BambooHR.Client.new(company_domain: "test_company", api_key: "test_key", base_url: base_url)
+
     [bypass: bypass, config: config]
   end
 

--- a/test/bamboo_hr/time_tracking_test.exs
+++ b/test/bamboo_hr/time_tracking_test.exs
@@ -4,7 +4,10 @@ defmodule BambooHR.TimeTrackingTest do
   setup do
     bypass = Bypass.open()
     base_url = "http://localhost:#{bypass.port}/api/gateway.php"
-    config = BambooHR.Client.new("test_company", "test_key", base_url)
+
+    config =
+      BambooHR.Client.new(company_domain: "test_company", api_key: "test_key", base_url: base_url)
+
     {:ok, bypass: bypass, config: config}
   end
 


### PR DESCRIPTION
💁 These changes update the implementation of `BambooHR.Client` to enable the HTTP client to be configurable by the end user as needed. A sane default is provided that uses `Req` for the low level HTTP client.