### PR TITLE
Actions: Reduce permissions for workflow jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,10 @@ jobs:
   test:
     name: Tests (Elixir ${{ matrix.elixir }} / OTP ${{ matrix.otp }})
     runs-on: ubuntu-latest
+    
+    permissions:
+      contents: read
+      pull-requests: write
 
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
     needs: [docs, test]
     runs-on: ubuntu-latest
 
+    permissions: {}
+
     steps:
       - name: Status of workflow jobs
         run: echo 'All jobs in this workflow have successfully run'
@@ -19,6 +21,8 @@ jobs:
   docs:
     name: Documentation
     runs-on: ubuntu-latest
+
+    permissions: {}
 
     env:
       MIX_ENV: dev

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -10,6 +10,9 @@ jobs:
   lint:
     name: Lint schema
     runs-on: ubuntu-latest
+
+    permissions: {}
+    
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,8 +17,13 @@ jobs:
   publish:
     name: Build and publish to hex.pm
     runs-on: ubuntu-22.04
+
+    permissions:
+      contents: write
+    
     env:
       HEX_API_KEY: ${{ secrets.HEX_API_KEY }}
+      
     steps:
     - name: Checkout
       uses: actions/checkout@v4


### PR DESCRIPTION
💁 In the spirit of applying least privilege to the permissions available to GitHub Actions, these changes set minimal permissions for workflow jobs that don't require permissions beyond being able to clone and checkout code, and elevated permissions for those which need to do more.