### PR TITLE
Enable actions/checkout to clone repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,14 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   required:
     name: Required
     needs: [docs, test]
     runs-on: ubuntu-latest
-
-    permissions: {}
 
     steps:
       - name: Status of workflow jobs
@@ -21,8 +22,6 @@ jobs:
   docs:
     name: Documentation
     runs-on: ubuntu-latest
-
-    permissions: {}
 
     env:
       MIX_ENV: dev

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -6,12 +6,13 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint schema
     runs-on: ubuntu-latest
-
-    permissions: {}
     
     steps:
       - name: Checkout code


### PR DESCRIPTION
💁 For `actions/checkout` to be able to clone this repository, the `GITHUB_TOKEN` needs permission to read the contents.