### PR TITLE
ci: Security updates for GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
     - name: Set up Elixir
       id: setup-beam
       uses: erlef/setup-beam@v1
@@ -72,6 +74,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
     - name: Set up Elixir
       uses: erlef/setup-beam@v1
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,18 +27,18 @@ jobs:
       MIX_ENV: dev
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
     - name: Set up Elixir
       id: setup-beam
-      uses: erlef/setup-beam@v1
+      uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
       with:
         version-file: '.tool-versions'
         version-type: 'strict'
     - name: Cache dependencies
       id: cache-deps
-      uses: actions/cache@v5
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         path: |
           _build
@@ -73,17 +73,17 @@ jobs:
       MIX_ENV: test
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
     - name: Set up Elixir
-      uses: erlef/setup-beam@v1
+      uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
       with:
         elixir-version: ${{matrix.elixir}}
         otp-version: ${{matrix.otp}}
     - name: Cache dependencies
       id: cache-deps
-      uses: actions/cache@v5
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         path: |
           _build

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -15,11 +15,11 @@ jobs:
     name: "Report Mix Dependencies"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: erlef/mix-dependency-submission@v1
+      - uses: erlef/mix-dependency-submission@c4a36104ac7614b1b66d0da6e8a1c7d6d07bc52b # v1.3.2
         with:
           install-deps: true
-      - uses: actions/dependency-review-action@v4
+      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
         if: "${{ github.event_name == 'pull_request' }}"

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: erlef/mix-dependency-submission@v1
         with:
           install-deps: true

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -16,13 +16,13 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Setup problem matchers
-        uses: r7kamura/redocly-problem-matchers@v1
+        uses: r7kamura/redocly-problem-matchers@3b6f82af579316596ff52f605498423b2a69e483 # v1.2.0
       - name: Lint OpenAPI schema
-        uses: mhiew/redoc-lint-github-action@v4
+        uses: mhiew/redoc-lint-github-action@1b3526395495e5c1346ebb81a67813aee757e86b # v4
         with:
           args: docs/openapi.yaml --format stylish
         env:

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Setup problem matchers
         uses: r7kamura/redocly-problem-matchers@v1
       - name: Lint OpenAPI schema

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,7 +56,9 @@ jobs:
       run: mix deps.get
 
     - name: Add changelog entry
-      run: echo -e "${{ inputs.changes }}" > RELEASE.md
+      run: echo -e "${INPUTS_CHANGES}" > RELEASE.md
+      env:
+        INPUTS_CHANGES: ${{ inputs.changes }}
 
     - name: Bump version, generate changelog, push to git, publish on hex.pm
       run: mix expublish.${{ inputs.version }} --branch=main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
       
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         token: ${{ secrets.GH_PUBLISH_PAT }}
         fetch-depth: 0
@@ -40,13 +40,13 @@ jobs:
 
     - name: Setup Elixir
       id: setup-beam
-      uses: erlef/setup-elixir@v1
+      uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
       with:
         version-file: '.tool-versions'
         version-type: 'strict'
 
     - name: Restore dependencies cache
-      uses: actions/cache@v5
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         path: deps
         key: ${{ runner.os }}-publish-mix-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-${{ hashFiles('**/mix.lock') }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,6 +31,7 @@ jobs:
         token: ${{ secrets.GH_PUBLISH_PAT }}
         fetch-depth: 0
         ref: main
+        persist-credentials: false
 
     - name: Git Config
       run: |


### PR DESCRIPTION
💁 These changes apply recommendations from [zizmor](https://zizmor.sh/), a static analysis tool for GitHub Actions.