### PR TITLE
chore: add Lefthook pre-commit hooks and development setup docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,60 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build/Test/Lint Commands
+- Setup environment: `mix setup`
+- Run all tests: `mix test`
+- Run single test: `mix test path/to/test_file.exs:line_number`
+- Run specific test file: `mix test path/to/test_file.exs`
+- Format code: `mix format`
+- Check formatting (CI): `mix format --check-formatted`
+- Static analysis: `mix credo`
+- Generate docs: `mix docs`
+- Check unused deps: `mix deps.unlock --check-unused`
+
+## Architecture
+
+This is an Elixir client library for the BambooHR API, published as `bamboo_hr` on Hex.pm.
+
+### Module Structure
+
+**Dependency flow:**
+```
+Company / Employee / TimeTracking  (resource modules)
+         ↓
+      BambooHR.Client              (HTTP routing + auth)
+         ↓
+   BambooHR.HTTPClient             (behaviour + Req impl)
+         ↓
+         Req                       (HTTP library)
+```
+
+- `BambooHR.Client` — Core struct (`t()`) holding `company_domain`, `api_key`, `base_url`, `http_client`. All resource functions receive a `Client.t()` as first argument. Auth uses Basic auth with `api_key:x` encoding. URL scheme: `{base_url}/{company_domain}/v1{path}`.
+- `BambooHR.HTTPClient` — Behaviour with a single `request/1` callback. `BambooHR.HTTPClient.Req` is the default implementation; tests inject a mock via Mox.
+- `BambooHR.Company`, `BambooHR.Employee`, `BambooHR.TimeTracking` — Resource modules that delegate to `Client.get/3` or `Client.post/3`. All public functions return `{:ok, data} | {:error, reason}`.
+
+### Testing Patterns
+- Bypass library mocks the HTTP layer at the TCP level (not Mox) for integration-style tests.
+- Each test module sets up a Bypass instance and builds a `Client.t()` pointing at the local Bypass port.
+- Tests run `async: true`.
+
+## Code Style Guidelines
+- All public functions must have `@spec` type specs and `@doc` documentation.
+- Handle errors with pattern matching; never raise from public API functions.
+- No Ecto in this project — remove the `has_many`/`belongs_to` guideline if it appears elsewhere.
+
+## CI
+- Test matrix: Elixir 1.17/1.18 × OTP 25/26/27. Linting and coverage run only on Elixir 1.18 + OTP 27.
+- Compilation, tests, and docs all use `--warnings-as-errors`.
+
+## Development Setup
+- Install dev tooling and activate hooks: `./bin/setup && mix setup`
+- `./bin/setup` installs actionlint, check-jsonschema, and lefthook via Homebrew, then runs `lefthook install`
+- Pre-commit hooks run in parallel: `mix format --check-formatted`, `actionlint`, `check-jsonschema` (workflow schema + dependabot schema)
+
+## Git Flow
+- Branch naming: `feature-description-ticket-id`
+- PRs should include tests and documentation updates
+
+At the end of every change, update CLAUDE.md with anything useful that would have been helpful at the start.

--- a/README.md
+++ b/README.md
@@ -112,6 +112,45 @@ clock_out_data = %{
 {:ok, _} = BambooHR.TimeTracking.clock_out(config, 123, clock_out_data)
 ```
 
+## Development
+
+### Requirements
+
+- Elixir 1.17+, Erlang/OTP 25+ (see `.tool-versions` for exact versions)
+- [Homebrew](https://brew.sh) (macOS/Linux) for dev tooling
+
+### Setup
+
+Install dependencies and git hooks:
+
+```bash
+./bin/setup
+mix setup
+```
+
+`./bin/setup` installs [actionlint](https://github.com/rhysd/actionlint), [check-jsonschema](https://github.com/python-jsonschema/check-jsonschema), and [Lefthook](https://github.com/evilmartians/lefthook) via Homebrew, then activates the pre-commit hooks.
+
+### Common commands
+
+```bash
+mix test                        # Run tests
+mix format                      # Format code
+mix credo --strict              # Static analysis
+mix docs                        # Generate documentation
+mix deps.unlock --check-unused  # Check for unused dependencies
+```
+
+### Pre-commit hooks
+
+Hooks run automatically on `git commit` (in parallel):
+
+| Hook | Files |
+|---|---|
+| `mix format --check-formatted` | `*.ex`, `*.exs` |
+| `actionlint` | `.github/workflows/*.yml` |
+| `check-jsonschema` (workflow schema) | `.github/workflows/*.yml` |
+| `check-jsonschema` (dependabot schema) | `.github/dependabot.yml` |
+
 ## License
 
 BambooHR is [released under the MIT license](LICENSE).

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+brew install actionlint check-jsonschema lefthook
+lefthook install

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,15 @@
+pre-commit:
+  parallel: true
+  commands:
+    mix-format:
+      glob: "*.{ex,exs}"
+      run: mix format --check-formatted
+    actionlint:
+      glob: ".github/workflows/*.yml"
+      run: actionlint {staged_files}
+    check-github-workflows:
+      glob: ".github/workflows/*.yml"
+      run: check-jsonschema --builtin-schema vendor.github-workflows {staged_files}
+    check-dependabot:
+      glob: ".github/dependabot.{yml,yaml}"
+      run: check-jsonschema --builtin-schema vendor.dependabot {staged_files}


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Add `lefthook.yml` with four parallel pre-commit hooks: `mix format --check-formatted`, `actionlint`, and `check-jsonschema` for both GitHub Actions workflow schema and Dependabot config schema
- Add `bin/setup` script to install required tools (`actionlint`, `check-jsonschema`, `lefthook`) via Homebrew and activate the hooks
- Document development setup requirements and commands in `README.md` and `CLAUDE.md`

## Test plan

- [x] Run `./bin/setup` on a clean machine and confirm tools are installed and `lefthook install` succeeds
- [x] Stage a badly formatted `.ex` file and confirm `mix-format` hook blocks the commit
- [x] Stage a malformed workflow file and confirm `actionlint` and `check-github-workflows` hooks block the commit
- [x] Stage a malformed `dependabot.yml` and confirm `check-dependabot` hook blocks the commit