### PR TITLE
build: upgrade to Elixir 1.19 and OTP 28

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,9 @@ jobs:
         restore-keys: ${{ runner.os }}-${{ env.MIX_ENV }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ steps.setup-beam.outputs.otp-version }}-
     - name: Install and compile dependencies
       if: steps.cache-deps.outputs.cache-hit != 'true'
-      run: mix do deps.get --only ${{ env.MIX_ENV }}, deps.compile
+      run: |
+        # shellcheck disable=SC1010
+        mix do deps.get --only ${{ env.MIX_ENV }}, deps.compile
     - name: Generate documentation
       run: mix docs --warnings-as-errors
 
@@ -62,11 +64,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        elixir: ['1.17', '1.18']
-        otp: ['25', '26', '27']
-        include:
+        elixir: ['1.17', '1.18', '1.19']
+        otp: ['25', '26', '27', '28']
+        exclude:
+          - elixir: '1.17'
+            otp: '28'
           - elixir: '1.18'
-            otp: '27'
+            otp: '28'
+          - elixir: '1.19'
+            otp: '25'
+        include:
+          - elixir: '1.19'
+            otp: '28'
             lint: true
 
     env:
@@ -92,7 +101,9 @@ jobs:
         restore-keys: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-
     - name: Install and compile dependencies
       if: steps.cache-deps.outputs.cache-hit != 'true'
-      run: mix do deps.get --only test, deps.compile
+      run: |
+        # shellcheck disable=SC1010
+        mix do deps.get --only test, deps.compile
     - name: Check that mix.lock is up to date
       run: mix deps.get --check-locked
       if: ${{ matrix.lint }}

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.18-otp-27
-erlang 27.2
+elixir 1.19-otp-28
+erlang 28.4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,8 +45,9 @@ Company / Employee / TimeTracking  (resource modules)
 - No Ecto in this project — remove the `has_many`/`belongs_to` guideline if it appears elsewhere.
 
 ## CI
-- Test matrix: Elixir 1.17/1.18 × OTP 25/26/27. Linting and coverage run only on Elixir 1.18 + OTP 27.
+- Test matrix: Elixir 1.17/1.18/1.19 × OTP 25/26/27/28, with unsupported combinations excluded (1.17+28, 1.18+28, 1.19+25). Linting and coverage run only on Elixir 1.19 + OTP 28.
 - Compilation, tests, and docs all use `--warnings-as-errors`.
+- `actionlint` runs shellcheck on `run:` blocks; use `# shellcheck disable=SC1010` for `mix do` steps (false positive — `do` is a Mix keyword, not a shell keyword).
 
 ## Development Setup
 - Install dev tooling and activate hooks: `./bin/setup && mix setup`

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ clock_out_data = %{
 
 ### Requirements
 
-- Elixir 1.17+, Erlang/OTP 25+ (see `.tool-versions` for exact versions)
+- Elixir 1.17+ / Erlang/OTP 25+ (see `.tool-versions` for exact versions used locally)
 - [Homebrew](https://brew.sh) (macOS/Linux) for dev tooling
 
 ### Setup

--- a/mix.exs
+++ b/mix.exs
@@ -12,10 +12,6 @@ defmodule BambooHR.MixProject do
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       elixirc_paths: elixirc_paths(Mix.env()),
-      preferred_cli_env: [
-        coveralls: :test,
-        "coveralls.html": :test
-      ],
       test_coverage: [
         ignore_modules: [BambooHR],
         tool: ExCoveralls
@@ -36,6 +32,15 @@ defmodule BambooHR.MixProject do
   def application do
     [
       extra_applications: [:logger]
+    ]
+  end
+
+  def cli do
+    [
+      preferred_envs: [
+        coveralls: :test,
+        "coveralls.html": :test
+      ]
     ]
   end
 

--- a/test/bamboo_hr/application_test.exs
+++ b/test/bamboo_hr/application_test.exs
@@ -8,18 +8,16 @@ defmodule BambooHR.ApplicationTest do
       assert Process.whereis(BambooHR.Supervisor) == pid
     end
 
-    test "supervisor has correct configuration" do
+    test "supervisor is registered under expected name" do
+      {:ok, pid} = BambooHR.Application.start(:normal, [])
+      assert Process.whereis(BambooHR.Supervisor) == pid
+    end
+
+    test "supervisor reports expected child counts" do
       {:ok, pid} = BambooHR.Application.start(:normal, [])
 
-      # Get supervisor configuration
-      assert {:state, {:local, supervised_module}, strategy, {[], %{}}, :undefined, _intensity,
-              _period, [], 0, _auto_shutdown, Supervisor.Default,
-              {:ok, {config, []}}} = :sys.get_state(pid)
-
-      # Verify supervisor configuration
-      assert strategy == :one_for_one
-      assert config[:strategy] == :one_for_one
-      assert supervised_module == BambooHR.Supervisor
+      assert %{active: 0, specs: 0, supervisors: 0, workers: 0} =
+               Supervisor.count_children(pid)
     end
   end
 end


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Bump local tooling (`.tool-versions`) to Elixir 1.19 / OTP 28.4
- Expand the CI test matrix to include Elixir 1.19 and OTP 28, with [unsupported combinations](https://hexdocs.pm/elixir/compatibility-and-deprecations.html#between-elixir-and-erlang-otp) excluded (1.17+28, 1.18+28, 1.19+25)
- Move the lint/coverage job to Elixir 1.19 + OTP 28
- Fix a test that relied on internal OTP supervisor state tuple layout, which changed shape in OTP 28 — replaced with two focused tests using public APIs (`Process.whereis/1` and `Supervisor.count_children/1`)
- Suppress `shellcheck` SC1010 false positives on `mix do` run steps in CI
- Migrate `preferred_cli_env` from `def project` to `def cli` (deprecation warning in Mix 1.19)