### PR TITLE
fix: Handle empty and non-JSON response bodies

### DIFF
--- a/lib/bamboo_hr/http_client.ex
+++ b/lib/bamboo_hr/http_client.ex
@@ -15,9 +15,11 @@ defmodule BambooHR.HTTPClient.Req do
 
   @impl true
   def request(opts) do
+    opts = Keyword.put(opts, :decode_body, false)
+
     case Req.request(opts) do
       {:ok, %{status: status, body: body}} when status in 200..299 ->
-        {:ok, body}
+        decode_body(body)
 
       {:ok, %{status: status, body: body}} ->
         {:error, %{status: status, body: body}}
@@ -26,4 +28,7 @@ defmodule BambooHR.HTTPClient.Req do
         {:error, error}
     end
   end
+
+  defp decode_body(""), do: {:ok, nil}
+  defp decode_body(body), do: Jason.decode(body)
 end

--- a/test/bamboo_hr/client_test.exs
+++ b/test/bamboo_hr/client_test.exs
@@ -126,6 +126,57 @@ defmodule BambooHR.ClientTest do
                BambooHR.Client.post("/test_path", config, json: request_data)
     end
 
+    test "handles 200 response with empty body", %{bypass: bypass, config: config} do
+      Bypass.expect_once(
+        bypass,
+        "POST",
+        "/api/gateway.php/test_company/v1/test_path",
+        fn conn ->
+          Plug.Conn.resp(conn, 200, "")
+        end
+      )
+
+      assert {:ok, nil} = BambooHR.Client.post("/test_path", config, json: %{})
+    end
+
+    test "handles 201 response with JSON body", %{bypass: bypass, config: config} do
+      response_data = %{"id" => 42}
+
+      Bypass.expect_once(
+        bypass,
+        "POST",
+        "/api/gateway.php/test_company/v1/test_path",
+        fn conn ->
+          conn
+          |> Plug.Conn.put_resp_header("content-type", "application/json")
+          |> Plug.Conn.resp(201, Jason.encode!(response_data))
+        end
+      )
+
+      assert {:ok, ^response_data} =
+               BambooHR.Client.post("/test_path", config, json: %{})
+    end
+
+    test "handles 5xx server error", %{bypass: bypass, config: config} do
+      error_response = %{"error" => "Internal Server Error"}
+
+      Bypass.expect_once(
+        bypass,
+        "POST",
+        "/api/gateway.php/test_company/v1/test_path",
+        fn conn ->
+          conn
+          |> Plug.Conn.put_resp_header("content-type", "application/json")
+          |> Plug.Conn.resp(500, Jason.encode!(error_response))
+        end
+      )
+
+      assert {:error, %{status: 500, body: body}} =
+               BambooHR.Client.post("/test_path", config, json: %{})
+
+      assert Jason.decode!(body) == error_response
+    end
+
     test "handles error response for POST", %{bypass: bypass, config: config} do
       request_data = %{"request" => "data"}
       error_response = %{"error" => "Bad request"}
@@ -145,6 +196,22 @@ defmodule BambooHR.ClientTest do
                BambooHR.Client.post("/test_path", config, json: request_data)
 
       assert Jason.decode!(body) == error_response
+    end
+  end
+
+  describe "network errors" do
+    test "handles connection failure for GET", %{bypass: bypass, config: config} do
+      Bypass.down(bypass)
+
+      assert {:error, %Req.TransportError{}} =
+               BambooHR.Client.get("/test_path", config, retry: false)
+    end
+
+    test "handles connection failure for POST", %{bypass: bypass, config: config} do
+      Bypass.down(bypass)
+
+      assert {:error, %Req.TransportError{}} =
+               BambooHR.Client.post("/test_path", config, json: %{}, retry: false)
     end
   end
 end

--- a/test/bamboo_hr/client_test.exs
+++ b/test/bamboo_hr/client_test.exs
@@ -53,6 +53,19 @@ defmodule BambooHR.ClientTest do
       assert {:ok, ^response_data} = BambooHR.Client.get("/test_path", config)
     end
 
+    test "handles 200 response with empty body", %{bypass: bypass, config: config} do
+      Bypass.expect_once(
+        bypass,
+        "GET",
+        "/api/gateway.php/test_company/v1/test_path",
+        fn conn ->
+          Plug.Conn.resp(conn, 200, "")
+        end
+      )
+
+      assert {:ok, nil} = BambooHR.Client.get("/test_path", config)
+    end
+
     test "handles error response for GET", %{bypass: bypass, config: config} do
       error_response = %{"error" => "Not found"}
 
@@ -67,8 +80,10 @@ defmodule BambooHR.ClientTest do
         end
       )
 
-      assert {:error, %{status: 404, body: ^error_response}} =
+      assert {:error, %{status: 404, body: body}} =
                BambooHR.Client.get("/test_path", config)
+
+      assert Jason.decode!(body) == error_response
     end
 
     test "handles unexpected error for GET", %{bypass: bypass, config: config} do
@@ -126,8 +141,10 @@ defmodule BambooHR.ClientTest do
         end
       )
 
-      assert {:error, %{status: 400, body: ^error_response}} =
+      assert {:error, %{status: 400, body: body}} =
                BambooHR.Client.post("/test_path", config, json: request_data)
+
+      assert Jason.decode!(body) == error_response
     end
   end
 end

--- a/test/bamboo_hr/company_test.exs
+++ b/test/bamboo_hr/company_test.exs
@@ -46,8 +46,10 @@ defmodule BambooHR.CompanyTest do
         end
       )
 
-      assert {:error, %{status: 401, body: ^error_response}} =
+      assert {:error, %{status: 401, body: body}} =
                BambooHR.Company.get_information(config)
+
+      assert Jason.decode!(body) == error_response
     end
 
     test "handles unexpected error", %{bypass: bypass, config: config} do
@@ -110,8 +112,10 @@ defmodule BambooHR.CompanyTest do
         end
       )
 
-      assert {:error, %{status: 403, body: ^error_response}} =
+      assert {:error, %{status: 403, body: body}} =
                BambooHR.Company.get_eins(config)
+
+      assert Jason.decode!(body) == error_response
     end
   end
 end

--- a/test/bamboo_hr/employee_test.exs
+++ b/test/bamboo_hr/employee_test.exs
@@ -83,7 +83,7 @@ defmodule BambooHR.EmployeeTest do
         end
       )
 
-      assert {:ok, _} = BambooHR.Employee.update(config, employee_id, update_data)
+      assert {:ok, nil} = BambooHR.Employee.update(config, employee_id, update_data)
     end
 
     test "handles error when updating employee", %{bypass: bypass, config: config} do
@@ -107,8 +107,10 @@ defmodule BambooHR.EmployeeTest do
         end
       )
 
-      assert {:error, %{status: 404, body: ^error_response}} =
+      assert {:error, %{status: 404, body: body}} =
                BambooHR.Employee.update(config, employee_id, update_data)
+
+      assert Jason.decode!(body) == error_response
     end
   end
 
@@ -161,8 +163,10 @@ defmodule BambooHR.EmployeeTest do
         end
       )
 
-      assert {:error, %{status: 401, body: ^error_response}} =
+      assert {:error, %{status: 401, body: body}} =
                BambooHR.Employee.get_directory(config)
+
+      assert Jason.decode!(body) == error_response
     end
   end
 end

--- a/test/bamboo_hr/time_tracking_test.exs
+++ b/test/bamboo_hr/time_tracking_test.exs
@@ -73,8 +73,10 @@ defmodule BambooHR.TimeTrackingTest do
         end
       )
 
-      assert {:error, %{status: 400, body: ^error_response}} =
+      assert {:error, %{status: 400, body: body}} =
                BambooHR.TimeTracking.get_timesheet_entries(config, params)
+
+      assert Jason.decode!(body) == error_response
     end
   end
 
@@ -138,8 +140,10 @@ defmodule BambooHR.TimeTrackingTest do
         end
       )
 
-      assert {:error, %{status: 400, body: ^error_response}} =
+      assert {:error, %{status: 400, body: body}} =
                BambooHR.TimeTracking.store_clock_entries(config, entries)
+
+      assert Jason.decode!(body) == error_response
     end
   end
 
@@ -196,8 +200,10 @@ defmodule BambooHR.TimeTrackingTest do
         end
       )
 
-      assert {:error, %{status: 400, body: ^error_response}} =
+      assert {:error, %{status: 400, body: body}} =
                BambooHR.TimeTracking.clock_in(config, employee_id, clock_data)
+
+      assert Jason.decode!(body) == error_response
     end
   end
 
@@ -252,8 +258,10 @@ defmodule BambooHR.TimeTrackingTest do
         end
       )
 
-      assert {:error, %{status: 400, body: ^error_response}} =
+      assert {:error, %{status: 400, body: body}} =
                BambooHR.TimeTracking.clock_out(config, employee_id, clock_data)
+
+      assert Jason.decode!(body) == error_response
     end
   end
 end


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Pass `decode_body: false` to `Req.request/1` to disable automatic JSON decoding
- Manually decode the response body with `Jason.decode/1` after receiving the raw response
- Return `{:ok, nil}` for empty bodies (e.g. `Employee.update/3` returns `200 ""`)
- Update tests to assert `{:ok, nil}` on empty-body success responses
- Update error-case tests to decode the raw body string before comparing, since error bodies are now returned as raw strings