### PR TITLE
refactor: Separate HTTPClient behaviour from Req implementation

### DIFF
--- a/lib/bamboo_hr/http_client.ex
+++ b/lib/bamboo_hr/http_client.ex
@@ -5,30 +5,3 @@ defmodule BambooHR.HTTPClient do
 
   @callback request(keyword()) :: {:ok, map()} | {:error, any()}
 end
-
-defmodule BambooHR.HTTPClient.Req do
-  @moduledoc """
-  HTTP client implementation using `Req`.
-  """
-
-  @behaviour BambooHR.HTTPClient
-
-  @impl true
-  def request(opts) do
-    opts = Keyword.put(opts, :decode_body, false)
-
-    case Req.request(opts) do
-      {:ok, %{status: status, body: body}} when status in 200..299 ->
-        decode_body(body)
-
-      {:ok, %{status: status, body: body}} ->
-        {:error, %{status: status, body: body}}
-
-      {:error, error} ->
-        {:error, error}
-    end
-  end
-
-  defp decode_body(""), do: {:ok, nil}
-  defp decode_body(body), do: Jason.decode(body)
-end

--- a/lib/bamboo_hr/http_client/req.ex
+++ b/lib/bamboo_hr/http_client/req.ex
@@ -1,0 +1,26 @@
+defmodule BambooHR.HTTPClient.Req do
+  @moduledoc """
+  HTTP client implementation using `Req`.
+  """
+
+  @behaviour BambooHR.HTTPClient
+
+  @impl true
+  def request(opts) do
+    opts = Keyword.put(opts, :decode_body, false)
+
+    case Req.request(opts) do
+      {:ok, %{status: status, body: body}} when status in 200..299 ->
+        decode_body(body)
+
+      {:ok, %{status: status, body: body}} ->
+        {:error, %{status: status, body: body}}
+
+      {:error, error} ->
+        {:error, error}
+    end
+  end
+
+  defp decode_body(""), do: {:ok, nil}
+  defp decode_body(body), do: Jason.decode(body)
+end


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Move `BambooHR.HTTPClient.Req` out of `lib/bamboo_hr/http_client.ex` into its own file at `lib/bamboo_hr/http_client/req.ex`
- `lib/bamboo_hr/http_client.ex` now contains only the `BambooHR.HTTPClient` behaviour definition
- No logic changes — this is a file reorganisation only