### PR TITLE
feat: add configurable request timeout to Client

### DIFF
--- a/lib/bamboo_hr/client.ex
+++ b/lib/bamboo_hr/client.ex
@@ -18,12 +18,13 @@ defmodule BambooHR.Client do
           company_domain: String.t(),
           api_key: String.t(),
           base_url: String.t(),
-          http_client: module()
+          http_client: module(),
+          timeout: non_neg_integer()
         }
 
   @type response :: {:ok, map()} | {:error, any()}
 
-  defstruct [:company_domain, :api_key, :base_url, :http_client]
+  defstruct [:company_domain, :api_key, :base_url, :http_client, :timeout]
 
   @doc """
   Creates a new client configuration.
@@ -34,6 +35,7 @@ defmodule BambooHR.Client do
     * `:api_key` - Your API key
     * `:base_url` - Optional. Custom base URL for the API (defaults to BambooHR's standard API URL)
     * `:http_client` - Optional. Module that implements the `HTTPClient` behavior. Defaults to `BambooHR.HTTPClient.Req`.
+    * `:timeout` - Optional. HTTP receive timeout in milliseconds. Defaults to `15_000`.
 
   ## Examples
 
@@ -60,12 +62,14 @@ defmodule BambooHR.Client do
     api_key = Keyword.fetch!(opts, :api_key)
     base_url = Keyword.get(opts, :base_url, "https://api.bamboohr.com/api/gateway.php")
     http_client = Keyword.get(opts, :http_client, BambooHR.HTTPClient.Req)
+    timeout = Keyword.get(opts, :timeout, 15_000)
 
     %__MODULE__{
       company_domain: company_domain,
       api_key: api_key,
       base_url: base_url,
-      http_client: http_client
+      http_client: http_client,
+      timeout: timeout
     }
   end
 
@@ -93,7 +97,11 @@ defmodule BambooHR.Client do
     url = build_url(client, path)
     headers = build_headers(client.api_key)
 
-    req_opts = Keyword.merge([headers: headers, method: method, url: url], opts)
+    req_opts =
+      Keyword.merge(
+        [headers: headers, method: method, url: url, receive_timeout: client.timeout],
+        opts
+      )
 
     client.http_client.request(req_opts)
   end

--- a/test/bamboo_hr/client_test.exs
+++ b/test/bamboo_hr/client_test.exs
@@ -33,6 +33,18 @@ defmodule BambooHR.ClientTest do
       assert config.api_key == "test_key"
       assert config.base_url == custom_url
     end
+
+    test "defaults timeout to 15_000" do
+      config = BambooHR.Client.new(company_domain: "test_company", api_key: "test_key")
+      assert config.timeout == 15_000
+    end
+
+    test "stores custom timeout value" do
+      config =
+        BambooHR.Client.new(company_domain: "test_company", api_key: "test_key", timeout: 30_000)
+
+      assert config.timeout == 30_000
+    end
   end
 
   describe "get/3" do


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Add a `:timeout` option to `BambooHR.Client.new/1` that controls the HTTP receive timeout
- Default the timeout to `15_000` milliseconds when not specified
- Pass the timeout through to Req as `receive_timeout:` in the private `request/4` function
- Add `timeout: non_neg_integer()` to the `@type t` spec and the struct definition
- Document the new option in the `@doc` for `new/1`
- Add tests for the default timeout value and custom timeout values