### PR TITLE
docs: Document configurable request timeout option

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ config = BambooHR.Client.new(
 ```
 
 | Option | Default | Description |
-|---|---|---|
+| --- | --- | --- |
 | `:base_url` | BambooHR API URL | Override the API base URL |
 | `:http_client` | `BambooHR.HTTPClient.Req` | Custom HTTP client module |
 | `:timeout` | `15_000` | HTTP receive timeout in milliseconds |

--- a/README.md
+++ b/README.md
@@ -53,9 +53,16 @@ config = BambooHR.Client.new(
   company_domain: "your_company",
   api_key: "your_api_key",
   base_url: "https://custom-api.example.com",
-  http_client: YourCustomHTTPClient
+  http_client: YourCustomHTTPClient,
+  timeout: 30_000
 )
 ```
+
+| Option | Default | Description |
+|---|---|---|
+| `:base_url` | BambooHR API URL | Override the API base URL |
+| `:http_client` | `BambooHR.HTTPClient.Req` | Custom HTTP client module |
+| `:timeout` | `15_000` | HTTP receive timeout in milliseconds |
 
 #### Company Information
 

--- a/lib/bamboo_hr/client.ex
+++ b/lib/bamboo_hr/client.ex
@@ -8,6 +8,11 @@ defmodule BambooHR.Client do
   - Your company's subdomain
   - An API key
 
+  Optional configuration:
+  - `:base_url` — override the default API base URL
+  - `:http_client` — swap in a custom HTTP client module
+  - `:timeout` — HTTP receive timeout in milliseconds (default: `15_000`)
+
   ## Usage
 
       client = BambooHR.Client.new(company_domain: "your_company", api_key: "your_api_key")
@@ -44,16 +49,18 @@ defmodule BambooHR.Client do
         company_domain: "acme",
         api_key: "api_key_123",
         base_url: "https://api.bamboohr.com/api/gateway.php",
-        http_client: BambooHR.HTTPClient.Req
+        http_client: BambooHR.HTTPClient.Req,
+        timeout: 15_000
       }
 
-      # With custom base URL
-      iex> client = BambooHR.Client.new(company_domain: "acme", api_key: "api_key_123", base_url: "https://custom-api.example.com")
+      # With custom base URL and timeout
+      iex> client = BambooHR.Client.new(company_domain: "acme", api_key: "api_key_123", base_url: "https://custom-api.example.com", timeout: 30_000)
       %{
         company_domain: "acme",
         api_key: "api_key_123",
         base_url: "https://custom-api.example.com",
-        http_client: BambooHR.HTTPClient.Req
+        http_client: BambooHR.HTTPClient.Req,
+        timeout: 30_000
       }
   """
   @spec new(Keyword.t()) :: t()


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Add `:timeout` to the optional configuration summary in `BambooHR.Client` `@moduledoc`
- Update the `iex>` examples in `Client.new/1` to show the `timeout` field in struct output and demonstrate a custom timeout value
- Add `:timeout` to the optional parameters example in the README
- Add an options reference table to the README's "Getting Started" section

Depends on #59.