### PR TITLE
build: add markdownlint-cli2 linting for markdown files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,24 @@ permissions:
 jobs:
   required:
     name: Required
-    needs: [docs, test]
+    needs: [docs, lint-markdown, test]
     runs-on: ubuntu-latest
 
     steps:
       - name: Status of workflow jobs
         run: echo 'All jobs in this workflow have successfully run'
+
+  lint-markdown:
+    name: Markdown lint
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - uses: DavidAnson/markdownlint-cli2-action@ce4853d43830c74c1753b39f3cf40f71c2031eb9 # v23.0.0
+      with:
+        globs: "**/*.md"
 
   docs:
     name: Documentation

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,6 +1,6 @@
 {
   // Exclude generated/vendored directories and files managed by tooling
-  "ignores": ["RELEASE.md", ".claude/", "_build/", "deps/"],
+  "ignores": ["CHANGELOG.md", ".claude/", "_build/", "deps/"],
   "config": {
     // Badge URLs and long code examples exceed 80 chars
     "MD013": false,

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,6 +1,6 @@
 {
-  // RELEASE.md is managed by release-please, not hand-authored
-  "ignores": ["RELEASE.md"],
+  // Exclude generated/vendored directories and files managed by tooling
+  "ignores": ["RELEASE.md", ".claude/", "_build/", "deps/"],
   "config": {
     // Badge URLs and long code examples exceed 80 chars
     "MD013": false,

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,10 @@
+{
+  // RELEASE.md is managed by release-please, not hand-authored
+  "ignores": ["RELEASE.md"],
+  "config": {
+    // Badge URLs and long code examples exceed 80 chars
+    "MD013": false,
+    // CHANGELOG repeats section names (## Added, ## Fixed) across versions
+    "MD024": false
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,23 +7,22 @@ adheres to [Semantic Versioning](http://semver.org/).
 ## 0.3.1 - 2025-04-25
 
 ### Changes
--Updated dependencies.
 
+- Updated dependencies.
 
 ## 0.3.0 - 2025-03-10
 
 ### Changed
-- Configurable HTTP client.
 
+- Configurable HTTP client.
 
 ## 0.2.0 - 2025-03-04
 
 ### Changed
+
 - Introduced new modules for Company, Employee and TimeTracking resources
 - Improved the package documentation
-
 
 ## 0.1.0 - 2025-01-29
 
 Initial release. :rocket:
-

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,7 @@
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 ## Build/Test/Lint Commands
+
 - Setup environment: `mix setup`
 - Run all tests: `mix test`
 - Run single test: `mix test path/to/test_file.exs:line_number`
@@ -20,7 +21,8 @@ This is an Elixir client library for the BambooHR API, published as `bamboo_hr` 
 ### Module Structure
 
 **Dependency flow:**
-```
+
+```text
 Company / Employee / TimeTracking  (resource modules)
          ↓
       BambooHR.Client              (HTTP routing + auth)
@@ -35,26 +37,31 @@ Company / Employee / TimeTracking  (resource modules)
 - `BambooHR.Company`, `BambooHR.Employee`, `BambooHR.TimeTracking` — Resource modules that delegate to `Client.get/3` or `Client.post/3`. All public functions return `{:ok, data} | {:error, reason}`.
 
 ### Testing Patterns
+
 - Bypass library mocks the HTTP layer at the TCP level (not Mox) for integration-style tests.
 - Each test module sets up a Bypass instance and builds a `Client.t()` pointing at the local Bypass port.
 - Tests run `async: true`.
 
 ## Code Style Guidelines
+
 - All public functions must have `@spec` type specs and `@doc` documentation.
 - Handle errors with pattern matching; never raise from public API functions.
 - No Ecto in this project — remove the `has_many`/`belongs_to` guideline if it appears elsewhere.
 
 ## CI
+
 - Test matrix: Elixir 1.17/1.18/1.19 × OTP 25/26/27/28, with unsupported combinations excluded (1.17+28, 1.18+28, 1.19+25). Linting and coverage run only on Elixir 1.19 + OTP 28.
 - Compilation, tests, and docs all use `--warnings-as-errors`.
 - `actionlint` runs shellcheck on `run:` blocks; use `# shellcheck disable=SC1010` for `mix do` steps (false positive — `do` is a Mix keyword, not a shell keyword).
 
 ## Development Setup
+
 - Install dev tooling and activate hooks: `./bin/setup && mix setup`
 - `./bin/setup` installs actionlint, check-jsonschema, and lefthook via Homebrew, then runs `lefthook install`
 - Pre-commit hooks run in parallel: `mix format --check-formatted`, `actionlint`, `check-jsonschema` (workflow schema + dependabot schema)
 
 ## Git Flow
+
 - Branch naming: `feature-description-ticket-id`
 - PRs should include tests and documentation updates
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ end
 ## Usage
 
 To use this client, you'll need information from BambooHR:
+
 - Your company's subdomain
 - An API key
 
@@ -145,7 +146,7 @@ mix deps.unlock --check-unused  # Check for unused dependencies
 Hooks run automatically on `git commit` (in parallel):
 
 | Hook | Files |
-|---|---|
+| --- | --- |
 | `mix format --check-formatted` | `*.ex`, `*.exs` |
 | `actionlint` | `.github/workflows/*.yml` |
 | `check-jsonschema` (workflow schema) | `.github/workflows/*.yml` |

--- a/bin/setup
+++ b/bin/setup
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-brew install actionlint check-jsonschema lefthook
+brew install actionlint check-jsonschema lefthook markdownlint-cli2
 lefthook install

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -13,3 +13,6 @@ pre-commit:
     check-dependabot:
       glob: ".github/dependabot.{yml,yaml}"
       run: check-jsonschema --builtin-schema vendor.dependabot {staged_files}
+    markdownlint:
+      glob: "*.md"
+      run: markdownlint-cli2 {staged_files}


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Add `markdownlint-cli2` to `bin/setup` alongside the existing Homebrew dev tools
- Add a `markdownlint` pre-commit hook in `lefthook.yml` scoped to `*.md` staged files
- Add a `lint-markdown` CI job in `ci.yml` using `DavidAnson/markdownlint-cli2-action` (SHA-pinned); add it to the `required` job's `needs`
- Add `.markdownlint-cli2.jsonc` with two rule overrides:
  - `MD013` (line length) disabled — badge URLs and long links make this impractical
  - `MD024` (duplicate headings) disabled — CHANGELOG repeats section names across versions
  - `RELEASE.md` excluded — managed by release-please, not hand-authored