### PR TITLE
build: Remove `package-name` from Release Please config

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -13,6 +13,12 @@ pre-commit:
     check-dependabot:
       glob: ".github/dependabot.{yml,yaml}"
       run: check-jsonschema --builtin-schema vendor.dependabot {staged_files}
+    check-release-please-config:
+      glob: "release-please-config.json"
+      run: check-jsonschema --schemafile https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json {staged_files}
+    check-release-please-manifest:
+      glob: ".release-please-manifest.json"
+      run: check-jsonschema --schemafile https://raw.githubusercontent.com/googleapis/release-please/main/schemas/manifest.json {staged_files}
     markdownlint:
       glob: "*.md"
       run: markdownlint-cli2 {staged_files}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,6 @@
   "packages": {
     ".": {
       "release-type": "elixir",
-      "package-name": "bamboo_hr",
       "changelog-path": "CHANGELOG.md",
       "changelog-sections": [
         {"type": "feat", "section": "Added"},


### PR DESCRIPTION
💁 These changes remove `package-name` from the root package. The value of `package-name` is added as a prefix to git tags and is not required for this repository with a single package.