### PR TITLE
CI: Decoupled job for code coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,49 @@ jobs:
       - name: Status of workflow jobs
         run: echo 'All jobs in this workflow have successfully run'
 
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      checks: write
+
+    env:
+      MIX_ENV: test
+
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - name: Set up Elixir
+      id: setup-beam
+      uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
+      with:
+        version-file: '.tool-versions'
+        version-type: 'strict'
+    - name: Cache dependencies
+      id: cache-deps
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+      with:
+        path: |
+          _build
+          deps
+        key: ${{ runner.os }}-${{ env.MIX_ENV }}-${{ steps.setup-beam.outputs.otp-version }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ hashFiles('**/mix.lock') }}
+        restore-keys: ${{ runner.os }}-${{ env.MIX_ENV }}-${{ steps.setup-beam.outputs.otp-version }}-${{ steps.setup-beam.outputs.elixir-version }}-
+    - name: Install and compile dependencies
+      if: steps.cache-deps.outputs.cache-hit != 'true'
+      run: |
+        # shellcheck disable=SC1010
+        mix do deps.get --only ${{ env.MIX_ENV }}, deps.compile
+    - name: Generate coverage report
+      run: mix coveralls.lcov
+    - name: Upload coverage to Coveralls
+      uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e # v2.3.7
+      with:
+        file: cover/lcov.info
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+
   docs:
     name: Documentation
     runs-on: ubuntu-latest
@@ -132,8 +175,3 @@ jobs:
       if: ${{ matrix.lint }}
     - name: Run tests
       run: mix test --warnings-as-errors
-    - name: Report code coverage to Coveralls
-      run: mix coveralls.github
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      if: ${{ matrix.lint }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,18 +19,6 @@ jobs:
       - name: Status of workflow jobs
         run: echo 'All jobs in this workflow have successfully run'
 
-  lint-markdown:
-    name: Markdown lint
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        persist-credentials: false
-    - uses: DavidAnson/markdownlint-cli2-action@ce4853d43830c74c1753b39f3cf40f71c2031eb9 # v23.0.0
-      with:
-        globs: "**/*.md"
-
   docs:
     name: Documentation
     runs-on: ubuntu-latest
@@ -64,6 +52,18 @@ jobs:
         mix do deps.get --only ${{ env.MIX_ENV }}, deps.compile
     - name: Generate documentation
       run: mix docs --warnings-as-errors
+
+  lint-markdown:
+    name: Markdown lint
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - uses: DavidAnson/markdownlint-cli2-action@ce4853d43830c74c1753b39f3cf40f71c2031eb9 # v23.0.0
+      with:
+        globs: "**/*.md"
 
   test:
     name: Tests (Elixir ${{ matrix.elixir }} / OTP ${{ matrix.otp }})

--- a/mix.exs
+++ b/mix.exs
@@ -39,7 +39,8 @@ defmodule BambooHR.MixProject do
     [
       preferred_envs: [
         coveralls: :test,
-        "coveralls.html": :test
+        "coveralls.html": :test,
+        "coveralls.lcov": :test
       ]
     ]
   end


### PR DESCRIPTION
💁 These changes separate code coverage reporting into a new CI job to prevent blocking failures if generation and upload of code coverage to Coveralls fails for any reason.