### PR TITLE
Automated version updates in package docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:bamboo_hr, "~> 0.3"}
+    {:bamboo_hr, "~> 0.4.0"}
   ]
 end
 ```

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ An Elixir client for the [Bamboo HR API][bamboohr-api-docs].
 The package can be installed by adding `bamboo_hr` to your
 list of dependencies in `mix.exs`:
 
+<!-- x-release-please-start-version -->
 ```elixir
 def deps do
   [
@@ -19,6 +20,7 @@ def deps do
   ]
 end
 ```
+<!-- x-release-please-end -->
 
 ## Usage
 


### PR DESCRIPTION
💁 These changes extend the existing Release Please configuration by wrapping the `bamboo_hr` dep with `x-release-please-start-version` and `x-release-please-end markers` so the [generic extra-file updater can locate and bump the version on each release](https://github.com/googleapis/release-please/blob/main/docs/customizing.md#updating-arbitrary-files). Corrects the constraint from ~> 0.3 to ~> 0.4.0 to match the current release.